### PR TITLE
chore: Introduzione al WG Roadmap Group

### DIFF
--- a/WG.md
+++ b/WG.md
@@ -93,3 +93,11 @@ Tutto ciò che riguarda la _gestione_, comunque la si intenda, passerà da qui. 
 
 Da notare che il Governance Group non avrà voce in capitolo sulle scelte di alcun altro gruppo purché queste siano nel loro perimetro e rispettino le nostre linee guida.  
 Per capirci, i membri del governance group non potranno rifiutarsi di condividere e accettare la decisione del drafting group nel cambiare le linee guida sulla stesura dei contenuti.
+
+## Roadmap Group
+
+_Presieduto da [Nome Cognome], [Nome Cognome], [Nome Cognome]._
+
+Il Roadmap Group è responsabile della definizione e della pubblicazione della roadmap generale del progetto, rappresentata sotto forma di file ROADMAP.md nella codebase del libro. Questo documento funge da guida per l'intero team, fornendo una pianificazione chiara dei passaggi chiave che devono essere seguiti per portare a termine il progetto con successo.
+
+Per maggiori dettagli sul Roadmap Group fare riferimento al [regolamento interno del gruppo](ROADMAP_GROUP.md).

--- a/wg/ROADMAP_GROUP.md
+++ b/wg/ROADMAP_GROUP.md
@@ -1,0 +1,23 @@
+# Roadmap Group
+
+_Presieduto da [Nome Cognome], [Nome Cognome], [Nome Cognome]._
+
+Il Roadmap Group è responsabile della definizione e della pubblicazione della roadmap generale del progetto, rappresentata sotto forma di file ROADMAP.md nella codebase del libro. Questo documento funge da guida per l'intero team, fornendo una pianificazione chiara dei passaggi chiave che devono essere seguiti per portare a termine il progetto con successo.
+
+## Compiti principali
+
+1. *Creazione della Roadmap*: Il Roadmap Group stabilisce e fissa i passaggi critici che devono essere completati per il successo del progetto. Questi passaggi includono la suddivisione del lavoro in capitoli, la definizione di obiettivi intermedi, la designazione di date di inizio e fine per i lavori su ciascun capitolo, e l'identificazione dei principali traguardi.
+
+2. *Monitoraggio dell'Avanzamento*: Il gruppo è responsabile di tenersi costantemente aggiornato sull'avanzamento dei lavori. Ciò include il monitoraggio dei progressi compiuti dai vari gruppi coinvolti nel processo di creazione del libro.
+
+3. *Aggiornamenti della Roadmap*: In base all'evolversi del progetto, il Roadmap Group apporta le modifiche necessarie alla roadmap, inclusi cambiamenti nelle date di rilascio e negli obiettivi intermedi. Queste modifiche vengono condivise con tutto il team.
+
+4. *Autorità sulla Pianificazione*: Il Roadmap Group ha l'autorità di escludere o includere parti del libro esclusivamente per ragioni di tempistiche ed avanzamento dei lavori. Queste decisioni non riguardano il contenuto del libro, ma piuttosto il rispetto delle scadenze e la gestione delle risorse.
+
+## Composizione del gruppo
+
+Il Roadmap Group è composto da membri con competenze nella gestione dei progetti, nella pianificazione, e nella comunicazione. È fondamentale che i membri del gruppo abbiano una visione chiara del progetto e siano in grado di mantenere una roadmap aggiornata e condivisa.
+
+## Autorità
+
+Il Roadmap Group ha l'autorità di modificare la roadmap in modo coerente con l'andamento del progetto e il rispetto delle tempistiche. Le decisioni del gruppo riguardano esclusivamente la pianificazione e la gestione delle risorse. L'obiettivo principale del gruppo è garantire che il progetto proceda in modo efficiente e rispetti le scadenze stabilite.

--- a/wg/ROADMAP_GROUP.md
+++ b/wg/ROADMAP_GROUP.md
@@ -6,13 +6,13 @@ Il Roadmap Group è responsabile della definizione e della pubblicazione della r
 
 ## Compiti principali
 
-1. *Creazione della Roadmap*: Il Roadmap Group stabilisce e fissa i passaggi critici che devono essere completati per il successo del progetto. Questi passaggi includono la suddivisione del lavoro in capitoli, la definizione di obiettivi intermedi, la designazione di date di inizio e fine per i lavori su ciascun capitolo, e l'identificazione dei principali traguardi.
+1. _Creazione della Roadmap_: Il Roadmap Group stabilisce e fissa i passaggi critici che devono essere completati per il successo del progetto. Questi passaggi includono la suddivisione del lavoro in capitoli, la definizione di obiettivi intermedi, la designazione di date di inizio e fine per i lavori su ciascun capitolo, e l'identificazione dei principali traguardi.
 
-2. *Monitoraggio dell'Avanzamento*: Il gruppo è responsabile di tenersi costantemente aggiornato sull'avanzamento dei lavori. Ciò include il monitoraggio dei progressi compiuti dai vari gruppi coinvolti nel processo di creazione del libro.
+2. _Monitoraggio dell'Avanzamento_: Il gruppo è responsabile di tenersi costantemente aggiornato sull'avanzamento dei lavori. Ciò include il monitoraggio dei progressi compiuti dai vari gruppi coinvolti nel processo di creazione del libro.
 
-3. *Aggiornamenti della Roadmap*: In base all'evolversi del progetto, il Roadmap Group apporta le modifiche necessarie alla roadmap, inclusi cambiamenti nelle date di rilascio e negli obiettivi intermedi. Queste modifiche vengono condivise con tutto il team.
+3. _Aggiornamenti della Roadmap_: In base all'evolversi del progetto, il Roadmap Group apporta le modifiche necessarie alla roadmap, inclusi cambiamenti nelle date di rilascio e negli obiettivi intermedi. Queste modifiche vengono condivise con tutto il team.
 
-4. *Autorità sulla Pianificazione*: Il Roadmap Group ha l'autorità di escludere o includere parti del libro esclusivamente per ragioni di tempistiche ed avanzamento dei lavori. Queste decisioni non riguardano il contenuto del libro, ma piuttosto il rispetto delle scadenze e la gestione delle risorse.
+4. _Autorità sulla Pianificazione_: Il Roadmap Group ha l'autorità di escludere o includere parti del libro esclusivamente per ragioni di tempistiche ed avanzamento dei lavori. Queste decisioni non riguardano il contenuto del libro, ma piuttosto il rispetto delle scadenze e la gestione delle risorse.
 
 ## Composizione del gruppo
 


### PR DESCRIPTION
Il compito principale del Roadmap Group sarà il definire, pubblicare, e mantenere aggiornata una ROADMAP.md che quindi servirà sia pubblicamente per manifestare lo stato di avanzamento dei lavori, sia internamente come coordinamento e guida per orientare i lavori