### PR TITLE
chore: Aggiunto nel README una descizione della struttura della codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,19 @@ Attualmente è composto da:
 - [Note dei meeting degli Ambassador](./meetings/)
 - [Eventi al quale il progetto ha partecipato](./events/)
 
-# Contribuire
+## Struttura file e cartelle
+
+Il repository è strutturato in cartelle, ognuna delle quali contiene un file `README.md` che ne descrive il contenuto.
+ 
+Questa è lista dettagliata delle cartelle
+
+- `events`: contiene le note degli eventi a cui il progetto ha partecipato, organizzate per data, la quantità si consiglia di creare delle sottocartelle per working group e per anno
+- `guidelines`: contiene le linee guida del progetto, organizzate per working group
+- `meetings`: contiene le note dei meeting degli Ambassador organizzate per data, la quantità si consiglia di creare delle sottocartelle per working group e per anno
+- `templates`: contiene i template per la governance del progetto, es. testi per la nomina degli Ambassador
+- `wg`: contiene i regolamenti interni di ogni working group
+
+## Contribuire
 
 Le contribuzioni al progetto saranno tendenzialmente limitate agli Ambassador.  
 Saranno comunque ben accette PR per correggere errori di battitura o di grammatica.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Attualmente è composto da:
 ## Struttura file e cartelle
 
 Il repository è strutturato in cartelle, ognuna delle quali contiene un file `README.md` che ne descrive il contenuto.
- 
+
 Questa è lista dettagliata delle cartelle
 
 - `events`: contiene le note degli eventi a cui il progetto ha partecipato, organizzate per data, la quantità si consiglia di creare delle sottocartelle per working group e per anno


### PR DESCRIPTION
Questo seconda descrizione anche se potrebbe sembrare ridodante ha l'obbiettivo di mettere a fuoco lo scopo di ogni cartella. Al contrario la sezione precedente a questa a quello invede di guidare chi atterra sulla codebase alla consultazione di un contenuto specifico.